### PR TITLE
4 vue router redirect

### DIFF
--- a/src/components/nav.vue
+++ b/src/components/nav.vue
@@ -1,8 +1,8 @@
 <template>
   <ul>
-    <router-link tag="li" to="/home" event="mouseover">home</router-link>
-    <router-link active-class="navLink" tag="li" to="/project" event="mouseover">project</router-link>
-    <router-link tag="li" to="/about" event="mouseover">about</router-link>
+    <router-link exact tag="li" to="/home">home</router-link>
+    <router-link exact active-class="navLink" tag="li" to="/project">project</router-link>
+    <router-link exact tag="li" to="/about">about</router-link>
   </ul>
 </template>
 <script type='text/ecmascript-6'>

--- a/src/components/other.vue
+++ b/src/components/other.vue
@@ -1,0 +1,9 @@
+<template>
+  <h1>i am other page!!!</h1>
+</template>
+<script type='text/ecmascript-6'>
+
+</script>
+<style>
+
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -16,7 +16,8 @@ let router = new VueRouter({
     },
     {
       path: '/home',
-      component: home
+      component: home,
+      alias: '/index'
     },
     {
       path: '/other',
@@ -25,24 +26,24 @@ let router = new VueRouter({
     {
       path: '/p404',
       component: p404
-    },
+    }
     // {
     //   path: '*',
     //   component: p404
     // }
     // ,
-    {
-      path: '*',
-      // redirect: {path: '/other'},
-      redirect: (to) => {
-        console.log(to)
-        if (to.path === '/123') {
-          return '/other'
-        } else {
-          return '/p404'
-        }
-      }
-    }
+    // {
+    //   path: '*',
+    //   // redirect: {path: '/other'},
+    //   redirect: (to) => {
+    //     console.log(to)
+    //     if (to.path === '/123') {
+    //       return '/other'
+    //     } else {
+    //       return '/p404'
+    //     }
+    //   }
+    // }
   ]
 })
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import VueRouter from 'vue-router'
 import home from '../components/home'
 import p404 from '../components/404'
 import nav from '../components/nav'
+import otherPage from '../components/other'
 
 Vue.use(VueRouter)
 let router = new VueRouter({
@@ -18,9 +19,29 @@ let router = new VueRouter({
       component: home
     },
     {
-      //  给没有路由的页面，指定404路由。
-      path: '*',
+      path: '/other',
+      component: otherPage
+    },
+    {
+      path: '/p404',
       component: p404
+    },
+    // {
+    //   path: '*',
+    //   component: p404
+    // }
+    // ,
+    {
+      path: '*',
+      // redirect: {path: '/other'},
+      redirect: (to) => {
+        console.log(to)
+        if (to.path === '/123') {
+          return '/other'
+        } else {
+          return '/p404'
+        }
+      }
     }
   ]
 })


### PR DESCRIPTION
1.增加redirect重定向路由属性，该属性可接受多种value。
  {
    path: '*',
    redirect: '/home'
    redirect: {path: '/home'}
    redirect: {name : 'About'}
    redirect: (to)=>{
        if(to.path ==='/index'){
            return '/home'
        }else{
           return '/p404'
       }
    }
 }

2. 给路由取别名：
{ path: '/home',
  name: 'Home',
  component: home,
  alias: '/index'   //这个就是别名，但是访问/index路由的时候，home的router-link不会被激活。
}