### PR TITLE
实现<router-view>的嵌套。修改上一次的document的组件被渲染到app.vue上的情况。

### DIFF
--- a/src/components/document.vue
+++ b/src/components/document.vue
@@ -1,7 +1,10 @@
 <template>
   <div>
     <p>我是文档页面！！</p>
+    <router-view></router-view>
+    <router-view name="slider"></router-view>
   </div>
+
 </template>
 <script type='text/ecmascript-6'>
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -57,11 +57,16 @@ let router = new VueRouter({
     },
     {
       path: '/document',
-      components: {
-        default: documentContent,
-        content: documentContent,
-        slider: documentMenu
-      }
+      component: document,
+      children: [
+        {
+          path: '',
+          components: {
+            default: documentContent,
+            slider: documentMenu
+          }
+        }
+      ]
     },
     {
       path: '/other',


### PR DESCRIPTION
实现<router-view>的嵌套。上一次提交，是在app.vue顶级出口上渲染的documentMenu和documentContent。这次想，点击导航document，是导航到document页面，menu和content被渲染到document.vue而不是之前的app.vue，所以就用到了<router-vieww>的嵌套来实现。1.首先，在index.js路由配置中，在document组件下，增加children属性，在内层在增加components属性。同时在document.vue中，使用两个<router-view>标签，一个标签渲染menu，一个标签渲染content。